### PR TITLE
Allow accessing data registered at the Schema level

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,5 @@
 use std::{
-    any::Any,
+    any::{Any, TypeId},
     collections::{HashMap, HashSet},
     ops::Deref,
     sync::Arc,
@@ -647,6 +647,15 @@ where
         request: impl Into<Request>,
     ) -> impl Stream<Item = Response> + Send + Unpin {
         self.execute_stream_with_session_data(request, Default::default())
+    }
+
+    /// Access global data stored in the Schema
+    pub fn data<D: Any + Send + Sync>(&self) -> Option<&D> {
+        self.0
+            .env
+            .data
+            .get(&TypeId::of::<D>())
+            .and_then(|d| d.downcast_ref::<D>())
     }
 }
 


### PR DESCRIPTION
Sometimes it can be useful to access the global data registered in a Schema (via SchemaBuilder) to compute some data to be inserted in a Request before processing it. This data itself is not global, and should only persist for the request. Being able to access global data here avoids having to needlessly carry around the data a second time.

Upstream PR: https://github.com/async-graphql/async-graphql/pull/1727