### PR TITLE
Mark generated interface methods as #[allow(missing_docs)]

### DIFF
--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -300,6 +300,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         let schema_ty = oty.value_type();
 
         methods.push(quote! {
+            #[allow(missing_docs)]
             #[inline]
             pub async fn #method_name<'ctx>(&self, #(#decl_params),*) -> #crate_name::Result<#ty> {
                 match self {

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -548,3 +548,24 @@ pub async fn test_interface_with_oneof_object() {
         })
     );
 }
+
+/// Module docs
+#[deny(missing_docs)]
+pub mod test_interface_docs {
+    use async_graphql::*;
+
+    /// Some object
+    #[derive(SimpleObject)]
+    pub struct MyObj {
+        id: i32,
+        title: String,
+    }
+
+    /// Some interface
+    #[derive(Interface)]
+    #[graphql(field(name = "id", ty = "&i32", desc = "Get the id"))]
+    pub enum Node {
+        /// Some objects
+        MyObj(MyObj),
+    }
+}


### PR DESCRIPTION
Otherwise using interface derives will fail in modules/crates built with `#[deny(missing_docs)]`

Upstream PR: https://github.com/async-graphql/async-graphql/pull/1730