### PR TITLE
Don't bail early on the first error when resolving containers

### DIFF
--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     extensions::ResolveInfo,
     parser::types::Selection,
-    resolver_utils::create_value_object,
+    resolver_utils::do_resolve_container,
 };
 
 /// Federation service
@@ -36,17 +36,7 @@ pub(crate) async fn resolve_container(
     let mut fields = Vec::new();
     collect_fields(&mut fields, schema, object, ctx, parent_value)?;
 
-    let res = if !serial {
-        futures_util::future::try_join_all(fields).await?
-    } else {
-        let mut results = Vec::with_capacity(fields.len());
-        for field in fields {
-            results.push(field.await?);
-        }
-        results
-    };
-
-    Ok(Some(create_value_object(res)))
+    Ok(Some(do_resolve_container(ctx, !serial, fields).await))
 }
 
 fn collect_typename_field<'a>(

--- a/src/resolver_utils/container.rs
+++ b/src/resolver_utils/container.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
-use futures_util::FutureExt;
+use futures_util::{FutureExt, StreamExt as _, stream::FuturesUnordered};
 use indexmap::IndexMap;
 
 use crate::{
@@ -140,14 +140,6 @@ pub async fn resolve_container_serial<'a, T: ContainerType + ?Sized>(
     resolve_container_inner(ctx, root, false).await
 }
 
-pub(crate) fn create_value_object(values: Vec<(Name, Value)>) -> Value {
-    let mut map = IndexMap::new();
-    for (name, value) in values {
-        insert_value(&mut map, name, value);
-    }
-    Value::Object(map)
-}
-
 fn insert_value(target: &mut IndexMap<Name, Value>, name: Name, value: Value) {
     if let Some(prev_value) = target.get_mut(&name) {
         if let Value::Object(target_map) = prev_value {
@@ -182,17 +174,37 @@ async fn resolve_container_inner<'a, T: ContainerType + ?Sized>(
     let mut fields = Fields(Vec::new());
     fields.add_set(ctx, root)?;
 
-    let res = if parallel {
-        futures_util::future::try_join_all(fields.0).await?
-    } else {
-        let mut results = Vec::with_capacity(fields.0.len());
-        for field in fields.0 {
-            results.push(field.await?);
-        }
-        results
+    Ok(do_resolve_container(ctx, parallel, fields.0).await)
+}
+
+pub(crate) async fn do_resolve_container<'a>(
+    ctx: &ContextSelectionSet<'a>,
+    parallel: bool,
+    futures: Vec<BoxFieldFuture<'a>>,
+) -> Value {
+    let mut results = IndexMap::new();
+    let mut handle = |res| match res {
+        Ok((name, value)) => insert_value(&mut results, name, value),
+        Err(e) => ctx.add_error(e),
     };
 
-    Ok(create_value_object(res))
+    if parallel {
+        let mut set = FuturesUnordered::new();
+        set.extend(futures);
+        while let Some(field) = set.next().await {
+            handle(field);
+        }
+    } else {
+        for fut in futures {
+            handle(fut.await);
+        }
+    }
+
+    if results.is_empty() {
+        Value::Null
+    } else {
+        Value::Object(results)
+    }
 }
 
 type BoxFieldFuture<'a> = Pin<Box<dyn Future<Output = ServerResult<(Name, Value)>> + 'a + Send>>;

--- a/tests/subscription_websocket_graphql_ws.rs
+++ b/tests/subscription_websocket_graphql_ws.rs
@@ -318,7 +318,9 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "next",
             "id": "1",
             "payload": {
-                "data": null,
+                "data": {
+                    "events": null,
+                },
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],

--- a/tests/subscription_websocket_subscriptions_transport_ws.rs
+++ b/tests/subscription_websocket_subscriptions_transport_ws.rs
@@ -255,7 +255,9 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "data",
             "id": "1",
             "payload": {
-                "data": null,
+                "data": {
+                    "events": null,
+                },
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],


### PR DESCRIPTION
Instead, resolve all fields fully and collect the errors in the context. This allows the request to return partial data (and multiple errors) as allowed by the GraphQL spec without needing to manually juggle this by hand.

Upstream PR: https://github.com/async-graphql/async-graphql/pull/1746