### PR TITLE
Add semantic nullability capability to async-graphql

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ playground = []
 raw_value = ["async-graphql-value/raw_value"]
 uuid-validator = ["uuid"]
 boxed-trait = ["async-graphql-derive/boxed-trait"]
+nullable-result = []
 
 [[bench]]
 harness = false

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -235,6 +235,8 @@ pub struct SimpleObjectField {
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
     pub complexity: Option<Expr>,
+    #[darling(default)]
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromDeriveInput)]
@@ -286,6 +288,8 @@ pub struct SimpleObject {
     pub guard: Option<Expr>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    #[darling(default)]
+    pub semantic_non_null: bool,
 }
 
 #[derive(FromMeta, Default)]
@@ -335,6 +339,8 @@ pub struct Object {
     pub guard: Option<Expr>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    #[darling(default)]
+    pub semantic_non_null: bool,
 }
 
 #[derive(FromMeta, Default)]
@@ -361,6 +367,7 @@ pub struct ObjectField {
     pub flatten: bool,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromMeta, Default, Clone)]
@@ -656,6 +663,8 @@ pub struct InterfaceField {
     pub override_from: Option<String>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    #[darling(default)]
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromVariant)]
@@ -694,6 +703,8 @@ pub struct Interface {
     pub tags: Vec<String>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    #[darling(default)]
+    pub semantic_non_null: bool,
     // for OneofObject
     #[darling(default)]
     pub input_name: Option<String>,
@@ -730,6 +741,7 @@ pub struct Subscription {
     pub guard: Option<Expr>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    pub semantic_non_null: bool,
 }
 
 #[derive(FromMeta, Default)]
@@ -758,6 +770,7 @@ pub struct SubscriptionField {
     pub complexity: Option<Expr>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromField)]
@@ -957,6 +970,7 @@ pub struct ComplexObject {
     pub rename_fields: Option<RenameRule>,
     pub rename_args: Option<RenameRule>,
     pub guard: Option<Expr>,
+    pub semantic_non_null: bool,
 }
 
 #[derive(FromMeta, Default)]
@@ -982,6 +996,7 @@ pub struct ComplexObjectField {
     pub flatten: bool,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromMeta, Default)]

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -141,7 +141,7 @@ pub fn generate(
                         .into())
                     }
                 };
-                let ty = ty.value_type();
+                let ty = ty.value_type(object_args.internal);
                 let ident = &method.sig.ident;
 
                 schema_fields.push(quote! {
@@ -332,7 +332,7 @@ pub fn generate(
                     .into())
                 }
             };
-            let schema_ty = ty.value_type();
+            let schema_ty = ty.value_type(object_args.internal);
             let visible = visible_fn(&method_args.visible);
 
             let complexity = if let Some(complexity) = &method_args.complexity {

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -377,6 +377,14 @@ pub fn generate(
             } else {
                 quote! { ::std::option::Option::None }
             };
+            let semantic_nullability = if method_args
+                .semantic_non_null
+                .unwrap_or(object_args.semantic_non_null)
+            {
+                quote! { <#schema_ty as #crate_name::OutputType>::semantic_nullability() }
+            } else {
+                quote! { #crate_name::registry::SemanticNullability::None }
+            };
 
             schema_fields.push(quote! {
                 #(#cfg_attrs)*
@@ -401,6 +409,7 @@ pub fn generate(
                     visible: #visible,
                     compute_complexity: #complexity,
                     directive_invocations: ::std::vec![ #(#directives),* ],
+                    semantic_nullability: #semantic_nullability,
                 }));
             });
 

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -160,6 +160,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         tags,
         override_from,
         directives,
+        semantic_non_null,
     } in &interface_args.fields
     {
         let (name, method_name) = if let Some(method) = method {
@@ -308,6 +309,12 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
             .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
             .collect::<Vec<_>>();
         let directives = gen_directive_calls(directives, TypeDirectiveLocation::FieldDefinition);
+        let semantic_nullability = if semantic_non_null.unwrap_or(interface_args.semantic_non_null)
+        {
+            quote! { <#schema_ty as #crate_name::OutputType>::semantic_nullability() }
+        } else {
+            quote! { #crate_name::registry::SemanticNullability::None }
+        };
 
         schema_fields.push(quote! {
             fields.insert(::std::string::ToString::to_string(#name), #crate_name::registry::MetaField {
@@ -331,6 +338,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
                 visible: #visible,
                 compute_complexity: ::std::option::Option::None,
                 directive_invocations: ::std::vec![ #(#directives),* ],
+                semantic_nullability: #semantic_nullability,
             });
         });
 

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -291,7 +291,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
             OutputType::Value(ty) => ty,
             OutputType::Result(ty) => ty,
         };
-        let schema_ty = oty.value_type();
+        let schema_ty = oty.value_type(interface_args.internal);
 
         methods.push(quote! {
             #[inline]

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -516,6 +516,14 @@ pub fn generate(
                 } else {
                     quote! { ::std::option::Option::None }
                 };
+                let semantic_nullability = if method_args
+                    .semantic_non_null
+                    .unwrap_or(object_args.semantic_non_null)
+                {
+                    quote! { <#schema_ty as #crate_name::OutputType>::semantic_nullability() }
+                } else {
+                    quote! { #crate_name::registry::SemanticNullability::None }
+                };
 
                 schema_fields.push(quote! {
                     #(#cfg_attrs)*
@@ -539,7 +547,8 @@ pub fn generate(
                         override_from: #override_from,
                         visible: #visible,
                         compute_complexity: #complexity,
-                        directive_invocations: ::std::vec![ #(#directives),* ]
+                        directive_invocations: ::std::vec![ #(#directives),* ],
+                        semantic_nullability: #semantic_nullability,
                     });
                 });
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -181,7 +181,7 @@ pub fn generate(
                     }
                 };
 
-                let entity_type = ty.value_type();
+                let entity_type = ty.value_type(object_args.internal);
                 let mut key_pat = Vec::new();
                 let mut key_getter = Vec::new();
                 let mut use_keys = Vec::new();
@@ -301,7 +301,7 @@ pub fn generate(
                             .into())
                         }
                     };
-                    let ty = ty.value_type();
+                    let ty = ty.value_type(object_args.internal);
                     let ident = &method.sig.ident;
 
                     schema_fields.push(quote! {
@@ -471,7 +471,7 @@ pub fn generate(
                         .into())
                     }
                 };
-                let schema_ty = ty.value_type();
+                let schema_ty = ty.value_type(object_args.internal);
                 let visible = visible_fn(&method_args.visible);
 
                 let complexity = if let Some(complexity) = &method_args.complexity {

--- a/derive/src/output_type.rs
+++ b/derive/src/output_type.rs
@@ -2,6 +2,8 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{Error, GenericArgument, PathArguments, Result, Type};
 
+use crate::utils::get_crate_name;
+
 pub enum OutputType<'a> {
     Value(&'a Type),
     Result(&'a Type),
@@ -42,10 +44,11 @@ impl<'a> OutputType<'a> {
         Ok(ty)
     }
 
-    pub fn value_type(&self) -> Type {
+    pub fn value_type(&self, internal: bool) -> Type {
+        let crate_name = get_crate_name(internal);
         let tokens = match self {
             OutputType::Value(ty) => quote! {#ty},
-            OutputType::Result(ty) => quote! {#ty},
+            OutputType::Result(ty) => quote! {#crate_name::Result<#ty>},
         };
         let mut ty = syn::parse2::<syn::Type>(tokens).unwrap();
         Self::remove_lifecycle(&mut ty);

--- a/derive/src/output_type.rs
+++ b/derive/src/output_type.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{Error, GenericArgument, PathArguments, Result, Type};
 
-use crate::utils::get_crate_name;
+use crate::utils::get_crate_path;
 
 pub enum OutputType<'a> {
     Value(&'a Type),
@@ -45,7 +45,7 @@ impl<'a> OutputType<'a> {
     }
 
     pub fn value_type(&self, internal: bool) -> Type {
-        let crate_name = get_crate_name(internal);
+        let crate_name = get_crate_path(&None, internal);
         let tokens = match self {
             OutputType::Value(ty) => quote! {#ty},
             OutputType::Result(ty) => quote! {#crate_name::Result<#ty>},

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -208,6 +208,14 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         } else {
             quote! { ::std::option::Option::None }
         };
+        let semantic_nullability = if field
+            .semantic_non_null
+            .unwrap_or(object_args.semantic_non_null)
+        {
+            quote! { <#ty as #crate_name::OutputType>::semantic_nullability() }
+        } else {
+            quote! { #crate_name::registry::SemanticNullability::None }
+        };
 
         if !field.flatten {
             schema_fields.push(quote! {
@@ -228,6 +236,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                     visible: #visible,
                     compute_complexity: #complexity,
                     directive_invocations: ::std::vec![ #(#directives),* ],
+                    semantic_nullability: #semantic_nullability,
                 });
             });
         } else {

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -266,6 +266,15 @@ pub fn generate(
             let directives =
                 gen_directive_calls(&field.directives, TypeDirectiveLocation::FieldDefinition);
 
+            let semantic_nullability = if field
+                .semantic_non_null
+                .unwrap_or(subscription_args.semantic_non_null)
+            {
+                quote! { <#output_ty as #crate_name::OutputType>::semantic_nullability() }
+            } else {
+                quote! { #crate_name::registry::SemanticNullability::None }
+            };
+
             schema_fields.push(quote! {
                 #(#cfg_attrs)*
                 fields.insert(::std::borrow::ToOwned::to_owned(#field_name), #crate_name::registry::MetaField {
@@ -288,7 +297,8 @@ pub fn generate(
                     inaccessible: false,
                     tags: ::std::default::Default::default(),
                     compute_complexity: #complexity,
-                    directive_invocations: ::std::vec![ #(#directives),* ]
+                    directive_invocations: ::std::vec![ #(#directives),* ],
+                    semantic_nullability: #semantic_nullability,
                 });
             });
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -11,7 +11,6 @@ use crate::{
     ContainerType, Context, ContextSelectionSet, Error, InputValueError, InputValueResult,
     Positioned, Result, ServerResult, Value,
     parser::types::Field,
-    registry::{self, Registry},
     registry::{self, Registry, SemanticNullability},
 };
 

--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -11,7 +11,7 @@ use indexmap::IndexMap;
 use super::Directive;
 use crate::{
     dynamic::{InputValue, ObjectAccessor, TypeRef},
-    registry::Deprecation,
+    registry::{Deprecation, SemanticNullability},
     Context, Error, Result, Value,
 };
 
@@ -333,6 +333,7 @@ pub struct Field {
     pub(crate) tags: Vec<String>,
     pub(crate) override_from: Option<String>,
     pub(crate) directives: Vec<Directive>,
+    pub(crate) semantic_nullability: SemanticNullability,
 }
 
 impl Debug for Field {
@@ -372,6 +373,7 @@ impl Field {
             tags: Vec::new(),
             override_from: None,
             directives: Vec::new(),
+            semantic_nullability: SemanticNullability::None,
         }
     }
 
@@ -384,6 +386,7 @@ impl Field {
     impl_set_inaccessible!();
     impl_set_tags!();
     impl_set_override_from!();
+    impl_set_semantic_nullability!();
     impl_directive!();
 
     /// Add an argument to the field

--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 
 use super::Directive;
 use crate::{
-    Context, Context, Error, Error, Result, Result, Value, Value,
+    Context, Error, Result, Value,
     dynamic::{InputValue, ObjectAccessor, TypeRef},
     registry::{Deprecation, SemanticNullability},
 };

--- a/src/dynamic/interface.rs
+++ b/src/dynamic/interface.rs
@@ -3,7 +3,7 @@ use indexmap::{IndexMap, IndexSet};
 use super::{directive::to_meta_directive_invocation, Directive};
 use crate::{
     dynamic::{InputValue, SchemaError, TypeRef},
-    registry::{Deprecation, MetaField, MetaType, Registry},
+    registry::{Deprecation, MetaField, MetaType, Registry, SemanticNullability},
 };
 
 /// A GraphQL interface field type
@@ -97,6 +97,7 @@ pub struct InterfaceField {
     pub(crate) tags: Vec<String>,
     pub(crate) override_from: Option<String>,
     pub(crate) directives: Vec<Directive>,
+    pub(crate) semantic_nullability: SemanticNullability,
 }
 
 impl InterfaceField {
@@ -116,6 +117,7 @@ impl InterfaceField {
             tags: Vec::new(),
             override_from: None,
             directives: Vec::new(),
+            semantic_nullability: SemanticNullability::None,
         }
     }
 
@@ -128,6 +130,7 @@ impl InterfaceField {
     impl_set_inaccessible!();
     impl_set_tags!();
     impl_set_override_from!();
+    impl_set_semantic_nullability!();
     impl_directive!();
 
     /// Add an argument to the field
@@ -248,6 +251,7 @@ impl Interface {
                     override_from: field.override_from.clone(),
                     compute_complexity: None,
                     directive_invocations: to_meta_directive_invocation(field.directives.clone()),
+                    semantic_nullability: field.semantic_nullability,
                 },
             );
         }

--- a/src/dynamic/macros.rs
+++ b/src/dynamic/macros.rs
@@ -162,6 +162,19 @@ macro_rules! impl_set_override_from {
     };
 }
 
+macro_rules! impl_set_semantic_nullability {
+    () => {
+        /// Semantic nullability
+        #[inline]
+        pub fn semantic_nullability(self, semantic_nullability: SemanticNullability) -> Self {
+            Self {
+                semantic_nullability,
+                ..self
+            }
+        }
+    };
+}
+
 macro_rules! impl_directive {
     () => {
         /// Attach directive to the entity

--- a/src/dynamic/object.rs
+++ b/src/dynamic/object.rs
@@ -189,6 +189,7 @@ impl Object {
                     override_from: field.override_from.clone(),
                     compute_complexity: None,
                     directive_invocations: to_meta_directive_invocation(field.directives.clone()),
+                    semantic_nullability: field.semantic_nullability,
                 },
             );
         }

--- a/src/dynamic/subscription.rs
+++ b/src/dynamic/subscription.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     extensions::ResolveInfo,
     parser::types::Selection,
-    registry::{Deprecation, MetaField, MetaType, Registry},
+    registry::{Deprecation, MetaField, MetaType, Registry, SemanticNullability},
     subscription::BoxFieldStream,
     ContextSelectionSet, Data, Name, QueryPathNode, QueryPathSegment, Response, Result,
     ServerResult, Value,
@@ -52,6 +52,7 @@ pub struct SubscriptionField {
     pub(crate) ty: TypeRef,
     pub(crate) resolver_fn: BoxResolverFn,
     pub(crate) deprecation: Deprecation,
+    pub(crate) semantic_nullability: SemanticNullability,
 }
 
 impl SubscriptionField {
@@ -69,11 +70,13 @@ impl SubscriptionField {
             ty: ty.into(),
             resolver_fn: Arc::new(resolver_fn),
             deprecation: Deprecation::NoDeprecated,
+            semantic_nullability: SemanticNullability::None,
         }
     }
 
     impl_set_description!();
     impl_set_deprecation!();
+    impl_set_semantic_nullability!();
 
     /// Add an argument to the subscription field
     #[inline]
@@ -163,6 +166,7 @@ impl Subscription {
                     override_from: None,
                     compute_complexity: None,
                     directive_invocations: vec![],
+                    semantic_nullability: field.semantic_nullability,
                 },
             );
         }

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -199,7 +199,7 @@ impl Registry {
                 return;
             }
 
-            writeln!(sdl, "{}", directive.sdl()).ok();
+            writeln!(sdl, "{}", directive.sdl(&options)).ok();
         });
 
         if options.federation {

--- a/src/types/external/cow.rs
+++ b/src/types/external/cow.rs
@@ -14,6 +14,10 @@ where
         T::type_name()
     }
 
+    fn semantic_nullability() -> registry::SemanticNullability {
+        T::semantic_nullability()
+    }
+
     fn create_type_info(registry: &mut registry::Registry) -> String {
         <T as OutputType>::create_type_info(registry)
     }

--- a/src/types/external/list/array.rs
+++ b/src/types/external/list/array.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     parser::types::Field, registry, resolver_utils::resolve_list, ContextSelectionSet, InputType,
     InputValueError, InputValueResult, OutputType, Positioned, ServerResult, Value,
@@ -60,6 +61,10 @@ impl<T: OutputType, const N: usize> OutputType for [T; N] {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/btree_set.rs
+++ b/src/types/external/list/btree_set.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::BTreeSet};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     parser::types::Field, registry, resolver_utils::resolve_list, ContextSelectionSet, InputType,
     InputValueError, InputValueResult, OutputType, Positioned, ServerResult, Value,
@@ -53,6 +54,10 @@ impl<T: OutputType + Ord> OutputType for BTreeSet<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/hash_set.rs
+++ b/src/types/external/list/hash_set.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::HashSet, hash::Hash};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     parser::types::Field, registry, resolver_utils::resolve_list, ContextSelectionSet, InputType,
     InputValueError, InputValueResult, OutputType, Positioned, Result, ServerResult, Value,
@@ -53,6 +54,10 @@ impl<T: OutputType + Hash + Eq> OutputType for HashSet<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/hashbrown_hash_set.rs
+++ b/src/types/external/list/hashbrown_hash_set.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, collections::HashSet as StdHashSet, hash::Hash};
 
 use hashbrown::HashSet;
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     parser::types::Field, registry, resolver_utils::resolve_list, ContextSelectionSet, InputType,
     InputValueError, InputValueResult, OutputType, Positioned, Result, ServerResult, Value,
@@ -54,6 +55,10 @@ impl<T: OutputType + Hash + Eq> OutputType for HashSet<T> {
 
     fn qualified_type_name() -> String {
         <StdHashSet<T> as OutputType>::qualified_type_name()
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/linked_list.rs
+++ b/src/types/external/list/linked_list.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::LinkedList};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     parser::types::Field, registry, resolver_utils::resolve_list, ContextSelectionSet, InputType,
     InputValueError, InputValueResult, OutputType, Positioned, ServerResult, Value,
@@ -54,6 +55,10 @@ impl<T: OutputType> OutputType for LinkedList<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/mod.rs
+++ b/src/types/external/list/mod.rs
@@ -1,3 +1,5 @@
+use crate::registry::SemanticNullability;
+
 mod array;
 mod btree_set;
 mod hash_set;
@@ -7,3 +9,18 @@ mod linked_list;
 mod slice;
 mod vec;
 mod vec_deque;
+
+fn wrap_semantic_nullability_in_list(
+    semantic_nullability: SemanticNullability,
+) -> SemanticNullability {
+    if cfg!(feature = "nullable-result") {
+        match semantic_nullability {
+            SemanticNullability::None => SemanticNullability::None,
+            SemanticNullability::OutNonNull => SemanticNullability::InNonNull,
+            SemanticNullability::InNonNull => SemanticNullability::InNonNull,
+            SemanticNullability::BothNonNull => SemanticNullability::BothNonNull,
+        }
+    } else {
+        semantic_nullability
+    }
+}

--- a/src/types/external/list/slice.rs
+++ b/src/types/external/list/slice.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     parser::types::Field, registry, resolver_utils::resolve_list, ContextSelectionSet, InputType,
     InputValueError, InputValueResult, OutputType, Positioned, ServerResult, Value,
@@ -13,6 +14,10 @@ impl<'a, T: OutputType + 'a> OutputType for &'a [T] {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {
@@ -39,6 +44,10 @@ macro_rules! impl_output_slice_for_smart_ptr {
 
             fn qualified_type_name() -> String {
                 format!("[{}]!", T::qualified_type_name())
+            }
+
+            fn semantic_nullability() -> registry::SemanticNullability {
+                wrap_semantic_nullability_in_list(T::semantic_nullability())
             }
 
             fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/vec.rs
+++ b/src/types/external/list/vec.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     parser::types::Field, registry, resolver_utils::resolve_list, ContextSelectionSet, InputType,
     InputValueError, InputValueResult, OutputType, Positioned, Result, ServerResult, Value,
@@ -51,6 +52,10 @@ impl<T: OutputType> OutputType for Vec<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/vec_deque.rs
+++ b/src/types/external/list/vec_deque.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::VecDeque};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     parser::types::Field, registry, resolver_utils::resolve_list, ContextSelectionSet, InputType,
     InputValueError, InputValueResult, OutputType, Positioned, ServerResult, Value,
@@ -54,6 +55,10 @@ impl<T: OutputType> OutputType for VecDeque<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/tokio/sync/mutex.rs
+++ b/src/types/external/tokio/sync/mutex.rs
@@ -11,6 +11,10 @@ impl<T: OutputType> OutputType for Mutex<T> {
         T::type_name()
     }
 
+    fn semantic_nullability() -> registry::SemanticNullability {
+        T::semantic_nullability()
+    }
+
     fn create_type_info(registry: &mut registry::Registry) -> String {
         <T as OutputType>::create_type_info(registry)
     }

--- a/src/types/external/tokio/sync/rw_lock.rs
+++ b/src/types/external/tokio/sync/rw_lock.rs
@@ -11,6 +11,10 @@ impl<T: OutputType> OutputType for RwLock<T> {
         T::type_name()
     }
 
+    fn semantic_nullability() -> registry::SemanticNullability {
+        T::semantic_nullability()
+    }
+
     fn create_type_info(registry: &mut registry::Registry) -> String {
         <T as OutputType>::create_type_info(registry)
     }

--- a/tests/error_ext.rs
+++ b/tests/error_ext.rs
@@ -38,7 +38,11 @@ pub async fn test_error_extensions() {
     assert_eq!(
         serde_json::to_value(&schema.execute("{ extendErr }").await).unwrap(),
         serde_json::json!({
-            "data": null,
+            "data": (if cfg!(feature = "nullable-result"){
+                serde_json::json!({ "extendErr": null })
+            } else {
+                serde_json::Value::Null
+            }),
             "errors": [{
                 "message": "my error",
                 "locations": [{
@@ -58,7 +62,11 @@ pub async fn test_error_extensions() {
     assert_eq!(
         serde_json::to_value(&schema.execute("{ extendResult }").await).unwrap(),
         serde_json::json!({
-            "data": null,
+            "data": (if cfg!(feature = "nullable-result"){
+                serde_json::json!({ "extendResult": null })
+            } else {
+                serde_json::Value::Null
+            }),
             "errors": [{
                 "message": "my error",
                 "locations": [{

--- a/tests/introspection.rs
+++ b/tests/introspection.rs
@@ -1539,7 +1539,7 @@ pub async fn test_introspection_directives() {
           }
         }
       }
-      
+
       fragment InputValue on __InputValue {
         name
         type {
@@ -1547,7 +1547,7 @@ pub async fn test_introspection_directives() {
         }
         defaultValue
       }
-      
+
       fragment TypeRef on __Type {
         kind
         name
@@ -1608,6 +1608,26 @@ pub async fn test_introspection_directives() {
             "INPUT_OBJECT"
           ],
           "args": []
+        },
+        {
+          "name": "semanticNonNull",
+          "locations": [
+            "FIELD_DEFINITION"
+          ],
+          "args": [
+            {
+              "name": "levels",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null
+                }
+              },
+              "defaultValue": "[0]"
+            }
+          ]
         },
         {
           "name": "skip",

--- a/tests/result.rs
+++ b/tests/result.rs
@@ -197,14 +197,6 @@ pub async fn test_error_propagation() {
     let resp = schema.execute("{ parent { child { name } } }").await;
 
     assert_eq!(
-        resp.data,
-        if cfg!(feature = "nullable-result") {
-            value!({ "parent": { "child": { "name": null } } })
-        } else {
-            Value::Null
-        }
-    );
-    assert_eq!(
         resp.errors,
         vec![ServerError {
             message: "myerror".to_string(),
@@ -223,14 +215,7 @@ pub async fn test_error_propagation() {
     );
 
     let resp = schema.execute("{ parent { childOpt { name } } }").await;
-    assert_eq!(
-        resp.data,
-        if cfg!(feature = "nullable-result") {
-            value!({ "parent": { "childOpt": { "name": null } } })
-        } else {
-            value!({ "parent": { "childOpt": null } })
-        }
-    );
+
     assert_eq!(
         resp.errors,
         vec![ServerError {
@@ -250,14 +235,7 @@ pub async fn test_error_propagation() {
     );
 
     let resp = schema.execute("{ parentOpt { child { name } } }").await;
-    assert_eq!(
-        resp.data,
-        if cfg!(feature = "nullable-result") {
-            value!({ "parentOpt": { "child": { "name": null } } })
-        } else {
-            value!({ "parentOpt": null })
-        }
-    );
+
     assert_eq!(
         resp.errors,
         vec![ServerError {
@@ -304,16 +282,31 @@ pub async fn test_error_propagation() {
         .await;
     assert_eq!(
         resp.data,
-        value!({
-            "parent": {
-                "child": {
-                    "ok": 42,
-                },
-                "childOpt": {
-                    "ok": 42,
-                },
-            }
-        })
+        if cfg!(feature = "nullable-result") {
+            value!({
+              "parent": {
+                  "child": {
+                      "ok": 42,
+                      "name": null,
+                  },
+                  "childOpt": {
+                      "ok": 42,
+                      "name": null,
+                  },
+              }
+            })
+        } else {
+            value!({
+                "parent": {
+                    "child": {
+                        "ok": 42,
+                    },
+                    "childOpt": {
+                        "ok": 42,
+                    },
+                }
+            })
+        }
     );
     assert_eq!(
         resp.errors,

--- a/tests/subscription_websocket_graphql_ws.rs
+++ b/tests/subscription_websocket_graphql_ws.rs
@@ -318,7 +318,13 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "next",
             "id": "1",
             "payload": {
-                "data": null,
+                "data": (
+                    if cfg!(feature = "nullable-result") {
+                        value!({ "events": { "value": null } })
+                    } else {
+                        Value::Null
+                    }
+                ),
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],

--- a/tests/subscription_websocket_graphql_ws.rs
+++ b/tests/subscription_websocket_graphql_ws.rs
@@ -321,18 +321,15 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "next",
             "id": "1",
             "payload": {
-                "data": (
-                    if cfg!(feature = "nullable-result") {
-                        value!({ "events": { "value": null } })
-                    } else {
-                        Value::Null
-                    }
-                ),
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],
                     "path": ["events", "value"],
                 }],
+                "data": {
+                    "events":  { "value": null }
+                },
+
             },
         })),
         serde_json::from_str(&stream.next().await.unwrap().unwrap_text()).unwrap()

--- a/tests/subscription_websocket_subscriptions_transport_ws.rs
+++ b/tests/subscription_websocket_subscriptions_transport_ws.rs
@@ -255,7 +255,13 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "data",
             "id": "1",
             "payload": {
-                "data": null,
+                "data": (
+                    if cfg!(feature = "nullable-result") {
+                        value!({ "events": { "value": null } })
+                    } else {
+                        Value::Null
+                    }
+                ),
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],

--- a/tests/subscription_websocket_subscriptions_transport_ws.rs
+++ b/tests/subscription_websocket_subscriptions_transport_ws.rs
@@ -255,18 +255,12 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "data",
             "id": "1",
             "payload": {
-                "data": (
-                    if cfg!(feature = "nullable-result") {
-                        value!({ "events": { "value": null } })
-                    } else {
-                        Value::Null
-                    }
-                ),
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],
                     "path": ["events", "value"],
                 }],
+                "data": { "events": { "value": null } },
             },
         })),
         serde_json::from_str(&stream.next().await.unwrap().unwrap_text()).unwrap()


### PR DESCRIPTION
The `nullable-result` and `semanticNonNull` branches are somewhat out of date on the remote, so this MR updates them to work with our latest async-graphql

The original MR is here: https://github.com/async-graphql/async-graphql/pull/1638